### PR TITLE
Change default mode of wordpress files to 0664

### DIFF
--- a/manifests/instance/app.pp
+++ b/manifests/instance/app.pp
@@ -47,7 +47,7 @@ define wordpress::instance::app (
   File {
     owner  => $wp_owner,
     group  => $wp_group,
-    mode   => '0644',
+    mode   => '0664',
   }
   Exec {
     path      => ['/bin','/sbin','/usr/bin','/usr/sbin'],


### PR DESCRIPTION
This will allow members of the group $wp_group to write to the wordpress directory, enabling them to run wp-cli etc without sudo.  There shouldn't be any risk here; by default, $wp_group is '0', i.e. root